### PR TITLE
feat: add notification provider

### DIFF
--- a/src/app/components/ArticleLayout.tsx
+++ b/src/app/components/ArticleLayout.tsx
@@ -9,6 +9,7 @@ import type { PathwayId, ArticleRef } from "@/content/pathways";
 import Newsletter from "./Newsletter";
 import { useAuth } from "@/app/context/AuthContext";
 import AuthModal from "./AuthModal";
+import { useNotification } from "./NotificationProvider";
 
 interface ResourceItem {
   title: string;
@@ -54,6 +55,7 @@ const ArticleLayout = ({
   const articleUrl = slug ? `${baseUrl}/${slug}` : baseUrl;
 
   const { token } = useAuth();
+  const { notify } = useNotification();
   const [showResources, setShowResources] = useState(false);
   const [isSaved, setIsSaved] = useState(false);
   const [showAuth, setShowAuth] = useState(false);
@@ -116,7 +118,7 @@ const ArticleLayout = ({
       } else {
         const data = await res.json();
         console.error("❌ Failed to save/unsave:", data);
-        alert(data.detail || "Something went wrong");
+        notify(data.detail || "Something went wrong", "error");
       }
     } catch (err) {
       console.error("❌ Error saving article:", err);

--- a/src/app/components/AuthModal.tsx
+++ b/src/app/components/AuthModal.tsx
@@ -5,6 +5,7 @@ import { Dialog } from "@headlessui/react";
 import { useAuth } from "../context/AuthContext";
 import { GoogleAuthProvider, signInWithPopup } from "firebase/auth";
 import { auth } from "../firebase";
+import { useNotification } from "./NotificationProvider";
 
 interface AuthModalProps {
   isOpen: boolean;
@@ -18,6 +19,7 @@ const AuthModal = ({ isOpen, onClose, onSuccess }: AuthModalProps) => {
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const { login } = useAuth();
+  const { notify } = useNotification();
 
   // 🔑 Google login flow
   const handleGoogleLogin = async () => {
@@ -38,7 +40,7 @@ const AuthModal = ({ isOpen, onClose, onSuccess }: AuthModalProps) => {
         onClose();
         if (onSuccess) onSuccess();
       } else if (data.preview) {
-        alert("You’re in preview mode (waitlist).");
+        notify("You’re in preview mode (waitlist).");
       }
     } catch (err) {
       console.error("Google login failed:", err);
@@ -64,7 +66,7 @@ const AuthModal = ({ isOpen, onClose, onSuccess }: AuthModalProps) => {
         onClose();
         if (onSuccess) onSuccess();
       } else {
-        alert("Failed to authenticate.");
+        notify("Failed to authenticate.", "error");
       }
     } finally {
       setLoading(false);

--- a/src/app/components/NotificationProvider.tsx
+++ b/src/app/components/NotificationProvider.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from "react";
+
+export type NotificationType = "info" | "success" | "error";
+
+interface Notification {
+  id: number;
+  message: string;
+  type: NotificationType;
+}
+
+interface NotificationContextValue {
+  notify: (message: string, type?: NotificationType) => void;
+}
+
+const NotificationContext = createContext<NotificationContextValue | undefined>(
+  undefined
+);
+
+export const NotificationProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+
+  const remove = (id: number) =>
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+
+  const notify = (message: string, type: NotificationType = "info") => {
+    const id = Date.now();
+    setNotifications((prev) => [...prev, { id, message, type }]);
+    setTimeout(() => remove(id), 5000);
+  };
+
+  return (
+    <NotificationContext.Provider value={{ notify }}>
+      {children}
+      <div className="fixed top-4 right-4 z-50 flex flex-col gap-2">
+        {notifications.map((n) => (
+          <div
+            key={n.id}
+            role="status"
+            aria-live="polite"
+            className={`flex items-start rounded-md px-4 py-3 text-sm text-white shadow-lg ${
+              n.type === "error"
+                ? "bg-red-600"
+                : n.type === "success"
+                ? "bg-green-600"
+                : "bg-gray-800"
+            }`}
+          >
+            <span className="flex-1">{n.message}</span>
+            <button
+              onClick={() => remove(n.id)}
+              aria-label="Dismiss notification"
+              className="ml-3 text-white/80 hover:text-white"
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+    </NotificationContext.Provider>
+  );
+};
+
+export const useNotification = () => {
+  const context = useContext(NotificationContext);
+  if (!context) {
+    throw new Error("useNotification must be used within NotificationProvider");
+  }
+  return context;
+};
+

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import Navbar from "./components/Navbar";
 import Footer from "./components/Footer";
 import { AuthProvider } from "./context/AuthContext"; // ✅ global auth provider
+import { NotificationProvider } from "./components/NotificationProvider";
 
 // 🎨 Fonts
 const quattrocento = Quattrocento({
@@ -33,11 +34,13 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${quattrocento.variable} ${montserrat.variable}`}>
       <body className="antialiased bg-white text-[#042a2b]">
-        <AuthProvider>
-          <Navbar />
-          <main className="pt-20 font-serif">{children}</main>
-          <Footer />
-        </AuthProvider>
+        <NotificationProvider>
+          <AuthProvider>
+            <Navbar />
+            <main className="pt-20 font-serif">{children}</main>
+            <Footer />
+          </AuthProvider>
+        </NotificationProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- add NotificationProvider with context and hook to show dismissible toast notifications
- wrap app with provider and replace alert calls in ArticleLayout and AuthModal

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Do not use an `<a>` element to navigate to `/insights/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages @next/next/no-html-link-for-pages)*
- `npm run build` *(fails: Failed to fetch `Montserrat` from Google Fonts.)*

------
https://chatgpt.com/codex/tasks/task_e_68abcfdda6d8832d97bf8b0dc6ce46d0