### PR TITLE
Improve login protection and newsletter UX

### DIFF
--- a/docs/backend-requirements.md
+++ b/docs/backend-requirements.md
@@ -1,0 +1,22 @@
+# Backend Requirements
+
+This frontend expects the `caveman_backend` project to provide:
+
+- **Authentication**
+  - JWT-based auth endpoints (`/auth/register`, `/auth/login`, `/auth/me`).
+  - Protect API routes and verify tokens.
+- **Spots API**
+  - `POST /spots` to save a spot for the authenticated user.
+  - `GET /spots` to retrieve spots for the authenticated user.
+- **Microchallenges API**
+  - Endpoints to fetch available microchallenges.
+  - Record per-user progress, e.g., `POST /microchallenges/:id/log`.
+- **Reading Materials Repository**
+  - Store books, articles and research papers with metadata linking them to relevant topics.
+  - Expose endpoints to query these resources.
+- **Admin Features**
+  - Upload and manage articles, books and papers.
+  - Create and manage microchallenges.
+  - View user data without direct database access.
+
+These services will support the frontend features added in this change.

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -32,9 +32,7 @@ const Navbar = () => {
           <div className="hidden md:flex items-center space-x-6 font-medium text-background">
             <Link href="/about" className="hover:text-brand-primary">About</Link>
             <Link href="/resources" className="hover:text-brand-primary">Resources</Link>
-            <Link href="/diagnostics" className="hover:text-brand-primary">Diagnostics</Link>
             <Link href="/services" className="hover:text-brand-primary">Services</Link>
-            <Link href="/contact" className="hover:text-brand-primary">Contact</Link>
 
             {/* Auth Section */}
             {user ? (
@@ -116,9 +114,7 @@ const Navbar = () => {
           <div className="flex flex-col px-6 py-4 space-y-4 font-medium">
             <Link href="/about" onClick={() => setIsOpen(false)} className="hover:text-brand-primary">About</Link>
             <Link href="/resources" onClick={() => setIsOpen(false)} className="hover:text-brand-primary">Resources</Link>
-            <Link href="/diagnostics" onClick={() => setIsOpen(false)} className="hover:text-brand-primary">Diagnostics</Link>
             <Link href="/services" onClick={() => setIsOpen(false)} className="hover:text-brand-primary">Services</Link>
-            <Link href="/contact" onClick={() => setIsOpen(false)} className="hover:text-brand-primary">Contact</Link>
 
             {/* Mobile Auth */}
             {user ? (

--- a/src/app/components/Newsletter.tsx
+++ b/src/app/components/Newsletter.tsx
@@ -14,12 +14,17 @@ const Newsletter = ({
   logoSrc = "/logo/newsletter.png",
 }: NewsletterProps) => {
   const [email, setEmail] = useState("");
+  const [subscribedEmail, setSubscribedEmail] = useState<string | null>(null);
   const [status, setStatus] = useState<"idle" | "subscribed">("idle");
 
   // ✅ Check localStorage on mount
   useEffect(() => {
-    if (typeof window !== "undefined" && localStorage.getItem("subscribed") === "true") {
-      setStatus("subscribed");
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("subscribedEmail");
+      if (stored) {
+        setSubscribedEmail(stored);
+        setStatus("subscribed");
+      }
     }
   }, []);
 
@@ -34,7 +39,8 @@ const Newsletter = ({
 
       const data = await res.json();
       if (data.status === "subscribed" || data.status === "already_subscribed") {
-        localStorage.setItem("subscribed", "true");
+        localStorage.setItem("subscribedEmail", email);
+        setSubscribedEmail(email);
         setStatus("subscribed");
       }
     } catch (err) {
@@ -80,9 +86,17 @@ const Newsletter = ({
             </button>
           </form>
         ) : (
-          <p className="text-xl text-brand-accent font-medium">
-            🎉 Thanks for joining! See you in your inbox.
-          </p>
+          <div className="flex flex-col items-center md:items-start gap-2">
+            <p className="text-xl text-brand-accent font-medium">
+              Subscribed as <span className="font-semibold">{subscribedEmail}</span>
+            </p>
+            <button
+              onClick={() => setStatus("idle")}
+              className="text-sm font-semibold px-3 py-1 rounded-lg bg-brand-secondary text-brand-dark hover:bg-brand-primary hover:text-background transition"
+            >
+              Subscribe with another email
+            </button>
+          </div>
         )}
       </div>
     </div>

--- a/src/app/components/tools/CavemanSpotting.tsx
+++ b/src/app/components/tools/CavemanSpotting.tsx
@@ -4,10 +4,8 @@ import CavemanSpot from "../ui/CavemanSpot";
 
 const CavemanSpotting = ({
   spots,
-  onAuthRequired,
 }: {
   spots: { date: string; description: string }[];
-  onAuthRequired?: () => void;
 }) => {
   const [allSpots, setAllSpots] = useState(spots);
 
@@ -23,8 +21,6 @@ const CavemanSpotting = ({
       {/* ✅ Inline Add Spot form (reusing CavemanSpot in inline mode) */}
       <CavemanSpot
         prompt="What’s one caveman instinct you spotted just now?"
-        mode="inline"
-        onAuthRequired={onAuthRequired}
         onAdded={(spot) => setAllSpots((prev) => [spot, ...prev])}
       />
 

--- a/src/app/components/tools/MicrochallengeBox.tsx
+++ b/src/app/components/tools/MicrochallengeBox.tsx
@@ -3,6 +3,9 @@
 
 import Link from "next/link";
 import { Zap } from "lucide-react";
+import { useState } from "react";
+import { useAuth } from "@/app/context/AuthContext";
+import AuthModal from "../AuthModal";
 
 interface MicrochallengeBoxProps {
   id: number;
@@ -11,6 +14,16 @@ interface MicrochallengeBoxProps {
 }
 
 const MicrochallengeBox = ({ id, title, blurb }: MicrochallengeBoxProps) => {
+  const { token } = useAuth();
+  const [showAuth, setShowAuth] = useState(false);
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (!token) {
+      e.preventDefault();
+      setShowAuth(true);
+    }
+  };
+
   return (
     <div className="my-6 p-4 border rounded-lg bg-[#f0fdff] border-[#5eb1bf] shadow-sm">
       <div className="flex items-center gap-2 mb-2">
@@ -21,9 +34,11 @@ const MicrochallengeBox = ({ id, title, blurb }: MicrochallengeBoxProps) => {
       <Link
         href={`/tools/microchallenges#challenge-${id}`}
         className="text-sm font-semibold text-[#5eb1bf] hover:underline"
+        onClick={handleClick}
       >
         Try this Microchallenge →
       </Link>
+      <AuthModal isOpen={showAuth} onClose={() => setShowAuth(false)} />
     </div>
   );
 };

--- a/src/app/components/ui/CavemanSpot.tsx
+++ b/src/app/components/ui/CavemanSpot.tsx
@@ -2,28 +2,28 @@
 
 import { useState } from "react";
 import { useAuth } from "@/app/context/AuthContext";
+import AuthModal from "../AuthModal";
 import { useNotification } from "../NotificationProvider";
 
 interface CavemanSpotProps {
-  prompt?: string;  // now optional, we’ll add a default
-  onAuthRequired?: () => void;
+  prompt?: string; // now optional, we’ll add a default
   onAdded?: (spot: { date: string; description: string }) => void;
 }
 
 const CavemanSpot = ({
   prompt = "Notice a caveman instinct? Log it here 👇",
-  onAuthRequired,
   onAdded,
 }: CavemanSpotProps) => {
   const [note, setNote] = useState("");
   const [submitted, setSubmitted] = useState(false);
+  const [showAuth, setShowAuth] = useState(false);
 
   const { token } = useAuth();
   const { notify } = useNotification();
 
   const handleSubmit = async () => {
     if (!token) {
-      onAuthRequired?.();
+      setShowAuth(true);
       return;
     }
     if (!note.trim()) {
@@ -80,6 +80,7 @@ const CavemanSpot = ({
       {submitted && (
         <p className="mt-2 text-sm text-green-700 font-medium">✅ Spot logged!</p>
       )}
+      <AuthModal isOpen={showAuth} onClose={() => setShowAuth(false)} />
     </div>
   );
 };

--- a/src/app/tools/microchallenges/page.tsx
+++ b/src/app/tools/microchallenges/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import { useAuth } from "@/app/context/AuthContext";
+import AuthModal from "../../components/AuthModal";
 
 const MicrochallengesPage = () => {
   // mock data
@@ -59,12 +61,19 @@ const MicrochallengesPage = () => {
 
   const [openId, setOpenId] = useState<number | null>(null);
   const [note, setNote] = useState("");
+  const [showAuth, setShowAuth] = useState(false);
+
+  const { token } = useAuth();
 
   const toggleOpen = (id: number) => {
     setOpenId(openId === id ? null : id);
   };
 
   const handleLog = () => {
+    if (!token) {
+      setShowAuth(true);
+      return;
+    }
     console.log("✔ Logged today!");
     setNote("");
   };
@@ -181,6 +190,7 @@ const MicrochallengesPage = () => {
           ← Back to Tools Dashboard
         </Link>
       </div>
+      <AuthModal isOpen={showAuth} onClose={() => setShowAuth(false)} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Show subscribed email and allow resubscription in newsletter form
- Require login via AuthModal for microchallenges and caveman spot logging
- Clean up navbar links and document backend API requirements

## Testing
- `npm run lint` *(fails: Unexpected any and unused vars)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad645f1a90832da93f19e2786b36fe