### PR TITLE
Add link checker and placeholders for missing routes

### DIFF
--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -1,0 +1,55 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const fs = require('fs');
+const path = require('path');
+
+const appDir = path.join(__dirname, '..', 'src', 'app');
+
+function getFiles(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const res = path.join(dir, entry.name);
+    return entry.isDirectory() ? getFiles(res) : [res];
+  });
+}
+
+function routeExists(link) {
+  const parts = link.split('/').filter(Boolean);
+  let current = appDir;
+  for (const part of parts) {
+    const direct = path.join(current, part);
+    if (fs.existsSync(direct)) {
+      current = direct;
+      continue;
+    }
+    const entries = fs.readdirSync(current);
+    const dynamic = entries.find(e => e.startsWith('[') && e.endsWith(']'));
+    if (dynamic) {
+      current = path.join(current, dynamic);
+    } else {
+      return false;
+    }
+  }
+  return fs.existsSync(path.join(current, 'page.tsx'));
+}
+
+const files = getFiles(appDir).filter(f => f.endsWith('.tsx'));
+const linkRegex = /href="(\/[^"#]+)"/g;
+const links = new Set();
+for (const file of files) {
+  const content = fs.readFileSync(file, 'utf8');
+  let match;
+  while ((match = linkRegex.exec(content)) !== null) {
+    const link = match[1];
+    if (!link.startsWith('http') && !link.startsWith('mailto:')) {
+      links.add(link);
+    }
+  }
+}
+
+const missing = [];
+for (const link of links) {
+  if (!routeExists(link)) {
+    missing.push(link);
+  }
+}
+
+console.log('Broken internal links:', missing);

--- a/src/app/components/ArticleLayout.tsx
+++ b/src/app/components/ArticleLayout.tsx
@@ -103,7 +103,6 @@ const ArticleLayout = ({
   if (!slug) return;
 
   let incremented = false; // 👈 reset every time slug changes
-  let timeout: NodeJS.Timeout;
 
   const markAsRead = () => {
     if (incremented) return; // only once per article
@@ -119,7 +118,7 @@ const ArticleLayout = ({
     }
 
     window.removeEventListener("scroll", onScroll);
-    if (timeout) clearTimeout(timeout);
+    clearTimeout(timeout);
   };
 
   const onScroll = () => {
@@ -134,7 +133,7 @@ const ArticleLayout = ({
     }
   };
 
-  timeout = setTimeout(() => {
+  const timeout = setTimeout(() => {
     markAsRead();
   }, 15000);
 
@@ -142,7 +141,7 @@ const ArticleLayout = ({
 
   return () => {
     window.removeEventListener("scroll", onScroll);
-    if (timeout) clearTimeout(timeout);
+    clearTimeout(timeout);
   };
 }, [slug, token]); // 👈 runs fresh for each article
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,8 @@
+export default function ContactPage() {
+  return (
+    <main className="prose mx-auto p-6 text-center">
+      <h1>Contact</h1>
+      <p>This page is under construction. Please check back soon.</p>
+    </main>
+  );
+}

--- a/src/app/diagnostics/caveman-scan/page.tsx
+++ b/src/app/diagnostics/caveman-scan/page.tsx
@@ -1,0 +1,8 @@
+export default function CavemanScanPage() {
+  return (
+    <main className="prose mx-auto p-6 text-center">
+      <h1>Caveman Scan</h1>
+      <p>This diagnostic is not yet available. Please check back soon.</p>
+    </main>
+  );
+}

--- a/src/app/diagnostics/spot-your-caveman/page.tsx
+++ b/src/app/diagnostics/spot-your-caveman/page.tsx
@@ -1,0 +1,8 @@
+export default function SpotYourCavemanPage() {
+  return (
+    <main className="prose mx-auto p-6 text-center">
+      <h1>Spot Your Caveman</h1>
+      <p>This diagnostic is not yet available. Please check back soon.</p>
+    </main>
+  );
+}

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,0 +1,8 @@
+export default function ServicesPage() {
+  return (
+    <main className="prose mx-auto p-6 text-center">
+      <h1>Services</h1>
+      <p>This page is under construction. Please check back soon.</p>
+    </main>
+  );
+}

--- a/src/app/subscribe/page.tsx
+++ b/src/app/subscribe/page.tsx
@@ -1,0 +1,8 @@
+export default function SubscribePage() {
+  return (
+    <main className="prose mx-auto p-6 text-center">
+      <h1>Subscribe</h1>
+      <p>Subscriptions are coming soon. Please check back later.</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add script to detect broken internal links
- create holding pages for services, contact, diagnostics, and subscribe routes
- refactor article layout timeout to satisfy lint rules

## Testing
- `node scripts/check-links.js`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68af17ee0044832dac212db73ce118db