### PR TITLE
Make top articles API route dynamic

### DIFF
--- a/src/app/api/articles/top/route.ts
+++ b/src/app/api/articles/top/route.ts
@@ -1,13 +1,15 @@
 import { NextResponse } from "next/server";
 
+export const dynamic = "force-dynamic";
+
 export async function GET() {
   try {
     const res = await fetch(`${process.env.API_BASE_URL}/articles/top`, {
       headers: {
         "Content-Type": "application/json",
       },
-      // 👇 ensures Next.js doesn’t cache the response
-      cache: "no-store",
+      // 👇 ensures Next.js revalidates on every request
+      next: { revalidate: 0 },
     });
 
     const data = await res.json();


### PR DESCRIPTION
## Summary
- add `dynamic = "force-dynamic"` export to top articles API route
- replace deprecated `cache: "no-store"` with `next: { revalidate: 0 }`

## Testing
- `npm run lint`
- `npm run build` *(fails: fetch failed for /api/challenges/route)*

------
https://chatgpt.com/codex/tasks/task_e_68b29a0293d8832da2d02b4d2f27b3ba