### PR TITLE
refactor(api): forward cookies for proxy auth

### DIFF
--- a/src/app/api/articles/[slug]/read/route.ts
+++ b/src/app/api/articles/[slug]/read/route.ts
@@ -6,12 +6,14 @@ export async function POST(
 ) {
   try {
     const { slug } = await context.params; // ✅ await params
+    const cookie = req.headers.get("cookie") || "";
 
     const res = await fetch(
       `${process.env.API_BASE_URL}/articles/${slug}/read`,
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", Cookie: cookie },
+        credentials: "include",
       }
     );
 

--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -5,14 +5,12 @@ const API_BASE_URL = process.env.API_BASE_URL;
 
 // ✅ GET /api/spots → fetch spots
 export async function GET(req: Request) {
-  const token = req.headers.get("authorization");
-
-  if (!token) {
-    return NextResponse.json({ detail: "Unauthorized" }, { status: 401 });
-  }
+  const cookie = req.headers.get("cookie") || "";
 
   const res = await fetch(`${API_BASE_URL}/spots`, {
-    headers: { Authorization: token },
+    method: "GET",
+    headers: { Cookie: cookie },
+    credentials: "include",
   });
 
   const data = await res.json();
@@ -21,11 +19,7 @@ export async function GET(req: Request) {
 
 // ✅ POST /api/spots → create new spot
 export async function POST(req: Request) {
-  const token = req.headers.get("authorization");
-
-  if (!token) {
-    return NextResponse.json({ detail: "Unauthorized" }, { status: 401 });
-  }
+  const cookie = req.headers.get("cookie") || "";
 
   const body = await req.json();
 
@@ -33,8 +27,9 @@ export async function POST(req: Request) {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: token,
+      Cookie: cookie,
     },
+    credentials: "include",
     body: JSON.stringify(body),
   });
 

--- a/src/app/api/articles/save/[slug]/route.ts
+++ b/src/app/api/articles/save/[slug]/route.ts
@@ -7,7 +7,7 @@ export async function POST(
   context: { params: Promise<{ slug: string }> }
 ) {
   const { slug } = await context.params;
-  const token = req.headers.get("authorization");
+  const cookie = req.headers.get("cookie") || "";
 
   let body: SaveBody = {};
   try {
@@ -21,8 +21,9 @@ export async function POST(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        ...(token ? { Authorization: token } : {}),
+        Cookie: cookie,
       },
+      credentials: "include",
       body: JSON.stringify(body),
     });
 
@@ -39,15 +40,16 @@ export async function DELETE(
   context: { params: Promise<{ slug: string }> }
 ) {
   const { slug } = await context.params;
-  const token = req.headers.get("authorization");
+  const cookie = req.headers.get("cookie") || "";
 
   try {
     const res = await fetch(`${process.env.API_BASE_URL}/articles/save/${slug}`, {
       method: "DELETE",
       headers: {
         "Content-Type": "application/json",
-        ...(token ? { Authorization: token } : {}),
+        Cookie: cookie,
       },
+      credentials: "include",
     });
 
     const data = await res.json();

--- a/src/app/api/articles/saved/[slug]/route.ts
+++ b/src/app/api/articles/saved/[slug]/route.ts
@@ -5,15 +5,13 @@ export async function GET(
   { params }: { params: Promise<{ slug: string }> }
 ) {
   const { slug } = await params;
-  const token = req.headers.get("authorization");
-
-  if (!token) {
-    return NextResponse.json({ detail: "Unauthorized" }, { status: 401 });
-  }
+  const cookie = req.headers.get("cookie") || "";
 
   // Proxy to backend
   const res = await fetch(`${process.env.API_BASE_URL}/articles/saved/${slug}`, {
-    headers: { Authorization: token },
+    method: "GET",
+    headers: { Cookie: cookie },
+    credentials: "include",
   });
 
   let data: unknown;

--- a/src/app/api/articles/saved/route.ts
+++ b/src/app/api/articles/saved/route.ts
@@ -1,18 +1,13 @@
 import { NextResponse } from "next/server";
 
 export async function GET(req: Request) {
-  const token = req.headers.get("authorization");
-
-  if (!token) {
-    return NextResponse.json(
-      { detail: "Unauthorized" },
-      { status: 401 }
-    );
-  }
+  const cookie = req.headers.get("cookie") || "";
 
   // Proxy to backend
   const res = await fetch(`${process.env.API_BASE_URL}/articles/saved`, {
-    headers: { Authorization: token },
+    method: "GET",
+    headers: { Cookie: cookie },
+    credentials: "include",
   });
 
   const data = await res.json();

--- a/src/app/api/articles/top/route.ts
+++ b/src/app/api/articles/top/route.ts
@@ -4,11 +4,13 @@ import { NextResponse } from "next/server";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
+    const cookie = req.headers.get("cookie") || "";
     const res = await fetch(`${process.env.API_BASE_URL}/articles/top`, {
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Cookie: cookie },
       cache: "no-store", // always fetch fresh, never cache at build
+      credentials: "include",
     });
 
     if (!res.ok) {

--- a/src/app/api/auth/firebase-login/route.ts
+++ b/src/app/api/auth/firebase-login/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 export async function POST(req: Request) {
   try {
     const body = await req.json();
+    const cookie = req.headers.get("cookie") || "";
     console.log(
       "📨 [Proxy] Received token:",
       body.idToken?.slice(0, 30),
@@ -13,7 +14,7 @@ export async function POST(req: Request) {
     const res = await fetch(`${process.env.API_BASE_URL}/auth/firebase-login`, {
       method: "POST",
       credentials: "include", // 👈 cookie exchange
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Cookie: cookie },
       body: JSON.stringify(body),
     });
 

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -2,11 +2,12 @@ import { NextResponse } from "next/server";
 
 export async function POST(req: Request) {
   const body = await req.json();
+  const cookie = req.headers.get("cookie") || "";
 
   const res = await fetch(`${process.env.API_BASE_URL}/auth/login`, {
     method: "POST",
     credentials: "include",   // 👈 allow cookie exchange
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", Cookie: cookie },
     body: JSON.stringify(body),
   });
 

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,18 +1,11 @@
 import { NextResponse } from "next/server";
 
 export async function GET(req: Request) {
-  // Forward Authorization header if present
-  const token = req.headers.get("authorization");
-
-  // Forward cookies from browser → backend
-  const cookieHeader = req.headers.get("cookie") || "";
+  const cookie = req.headers.get("cookie") || "";
 
   const res = await fetch(`${process.env.API_BASE_URL}/auth/me`, {
     method: "GET",
-    headers: {
-      ...(token ? { Authorization: token } : {}),
-      cookie: cookieHeader,
-    },
+    headers: { Cookie: cookie },
     credentials: "include",
   });
 

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -2,11 +2,12 @@ import { NextResponse } from "next/server";
 
 export async function POST(req: Request) {
   const body = await req.json();
+  const cookie = req.headers.get("cookie") || "";
 
   const res = await fetch(`${process.env.API_BASE_URL}/auth/signup`, {
     method: "POST",
     credentials: "include",   // 👈 allow cookie exchange
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", Cookie: cookie },
     body: JSON.stringify(body),
   });
 

--- a/src/app/api/challenges/[id]/route.ts
+++ b/src/app/api/challenges/[id]/route.ts
@@ -7,10 +7,12 @@ export async function GET(
   context: { params: Promise<{ id: string }> }   // 👈 match RouteHandlerConfig
 ) {
   const { id } = await context.params;          // 👈 await since it's a Promise
-  const token = request.headers.get("authorization");
+  const cookie = request.headers.get("cookie") || "";
 
   const res = await fetch(`${API_BASE_URL}/challenges/${id}`, {
-    headers: token ? { Authorization: token } : {},
+    method: "GET",
+    headers: { Cookie: cookie },
+    credentials: "include",
   });
 
   const data = await res.json();

--- a/src/app/api/challenges/assign/[id]/route.ts
+++ b/src/app/api/challenges/assign/[id]/route.ts
@@ -3,16 +3,14 @@ import { NextRequest, NextResponse } from "next/server";
 const API_BASE_URL = process.env.API_BASE_URL;
 
 export async function POST(req: NextRequest) {
-  const token = req.headers.get("authorization");
-  if (!token) {
-    return NextResponse.json({ detail: "Unauthorized" }, { status: 401 });
-  }
+  const cookie = req.headers.get("cookie") || "";
 
   const id = req.nextUrl.pathname.split("/").pop();
 
   const res = await fetch(`${API_BASE_URL}/challenges/assign/${id}`, {
     method: "POST",
-    headers: { Authorization: token },
+    headers: { Cookie: cookie },
+    credentials: "include",
   });
 
   const data = await res.json();

--- a/src/app/api/challenges/complete/[id]/route.ts
+++ b/src/app/api/challenges/complete/[id]/route.ts
@@ -7,15 +7,12 @@ export async function POST(
   context: { params: Promise<{ id: string }> }
 ) {
   const { id } = await context.params;
-
-  const token = req.headers.get("authorization");
-  if (!token) {
-    return NextResponse.json({ detail: "Unauthorized" }, { status: 401 });
-  }
+  const cookie = req.headers.get("cookie") || "";
 
   const res = await fetch(`${API_BASE_URL}/challenges/assign/${id}`, {
     method: "POST",
-    headers: { Authorization: token },
+    headers: { Cookie: cookie },
+    credentials: "include",
   });
 
   const data = await res.json();

--- a/src/app/api/challenges/my/route.ts
+++ b/src/app/api/challenges/my/route.ts
@@ -3,13 +3,12 @@ import { NextResponse } from "next/server";
 const API_BASE_URL = process.env.API_BASE_URL;
 
 export async function GET(req: Request) {
-  const token = req.headers.get("authorization");
-  if (!token) {
-    return NextResponse.json({ detail: "Unauthorized" }, { status: 401 });
-  }
+  const cookie = req.headers.get("cookie") || "";
 
   const res = await fetch(`${API_BASE_URL}/challenges/my`, {
-    headers: { Authorization: token },
+    method: "GET",
+    headers: { Cookie: cookie },
+    credentials: "include",
   });
 
   const data = await res.json();

--- a/src/app/api/challenges/route.ts
+++ b/src/app/api/challenges/route.ts
@@ -7,11 +7,13 @@ const API_BASE_URL = process.env.API_BASE_URL;
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-export async function GET() {
+export async function GET(req: Request) {
   try {
+    const cookie = req.headers.get("cookie") || "";
     const res = await fetch(`${API_BASE_URL}/challenges`, {
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Cookie: cookie },
       cache: "no-store", // always fresh
+      credentials: "include",
     });
 
     if (!res.ok) {

--- a/src/app/api/nudges/route.ts
+++ b/src/app/api/nudges/route.ts
@@ -1,8 +1,11 @@
 // app/api/nudges/random/route.ts
 import { NextResponse } from "next/server";
 
-export async function GET() {
+export async function GET(req: Request) {
+  const cookie = req.headers.get("cookie") || "";
   const res = await fetch(`${process.env.API_BASE_URL}/api/nudges/random`, {
+    method: "GET",
+    headers: { Cookie: cookie },
     credentials: "include",
   });
 

--- a/src/app/api/spots/route.ts
+++ b/src/app/api/spots/route.ts
@@ -4,18 +4,16 @@ const API_BASE_URL = process.env.API_BASE_URL;
 
 // GET /api/spots → list spots
 export async function GET(req: Request) {
-  const token = req.headers.get("authorization");
-
-  if (!token) {
-    return NextResponse.json({ detail: "Unauthorized" }, { status: 401 });
-  }
+  const cookie = req.headers.get("cookie") || "";
 
   try {
     const res = await fetch(`${process.env.API_BASE_URL}/api/spots`, {
+      method: "GET",
       headers: {
-        Authorization: token,
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        Cookie: cookie,
       },
+      credentials: "include",
     });
 
     const data = await res.json();
@@ -29,17 +27,13 @@ export async function GET(req: Request) {
 
 // POST /api/spots → create a new spot
 export async function POST(req: Request) {
-  const token = req.headers.get("authorization");
-
-  if (!token) {
-    return NextResponse.json({ detail: "Unauthorized" }, { status: 401 });
-  }
+  const cookie = req.headers.get("cookie") || "";
 
   const body = await req.json();
 
   // ✅ FIXED: Frontend already sends { description, date }, so pass it through directly
   const payload = {
-    description: body.description,  // ✅ Frontend sends description, not note
+    description: body.description, // ✅ Frontend sends description, not note
 
   };
 
@@ -47,8 +41,9 @@ export async function POST(req: Request) {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: token,
+      Cookie: cookie,
     },
+    credentials: "include",
     body: JSON.stringify(payload),
   });
 

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -2,13 +2,14 @@ import { NextResponse } from "next/server";
 
 export async function POST(req: Request) {
   const { email } = await req.json();
+  const cookie = req.headers.get("cookie") || "";
 
   try {
     const res = await fetch(`${process.env.API_BASE_URL}/api/subscribe`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Cookie: cookie },
       body: JSON.stringify({ email }),
-      // You can also forward cookies/auth headers if needed
+      credentials: "include",
     });
 
     const data = await res.json();

--- a/src/app/api/usage/route.ts
+++ b/src/app/api/usage/route.ts
@@ -4,9 +4,11 @@ const API_BASE_URL = process.env.API_BASE_URL;
 
 // GET /api/usage -> fetch current usage counts
 export async function GET(req: Request) {
-  const token = req.headers.get("authorization") || "";
+  const cookie = req.headers.get("cookie") || "";
   const res = await fetch(`${API_BASE_URL}/usage`, {
-    headers: { Authorization: token },
+    method: "GET",
+    headers: { Cookie: cookie },
+    credentials: "include",
   });
   const data = await res.json();
   return NextResponse.json(data, { status: res.status });
@@ -14,14 +16,15 @@ export async function GET(req: Request) {
 
 // POST /api/usage -> record a usage event
 export async function POST(req: Request) {
-  const token = req.headers.get("authorization") || "";
+  const cookie = req.headers.get("cookie") || "";
   const body = await req.json();
   const res = await fetch(`${API_BASE_URL}/usage`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: token,
+      Cookie: cookie,
     },
+    credentials: "include",
     body: JSON.stringify(body),
   });
   const data = await res.json();

--- a/src/app/api/weekly-reflection/latest/route.ts
+++ b/src/app/api/weekly-reflection/latest/route.ts
@@ -6,10 +6,11 @@ export async function GET(req: Request) {
   const cookie = req.headers.get("cookie") || "";
 
   // 2. Forward them to FastAPI
-const res = await fetch(`${process.env.API_BASE_URL}/api/weekly-reflection/latest`, {
-  method: "GET",
-  credentials: "include",   // 👈 this will forward cookies
-});
+  const res = await fetch(`${process.env.API_BASE_URL}/api/weekly-reflection/latest`, {
+    method: "GET",
+    headers: { Cookie: cookie },
+    credentials: "include", // 👈 this will forward cookies
+  });
 
 
   const data = await res.json();


### PR DESCRIPTION
## Summary
- forward incoming cookies to backend across all proxy routes
- remove token-based auth checks and use `credentials: "include"`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b6944c9838832dad9454dc61c37b78