### PR TITLE
Fix auth flows and slugify tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run --coverage"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.7",
@@ -35,6 +36,10 @@
     "eslint": "^9",
     "eslint-config-next": "15.5.0",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^2.1.1",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "jsdom": "^24.0.0"
   }
 }

--- a/src/app/caveman-cubicle/page.tsx
+++ b/src/app/caveman-cubicle/page.tsx
@@ -1,0 +1,8 @@
+export default function CavemanCubiclePage() {
+  return (
+    <main className="max-w-3xl mx-auto px-6 py-20 text-center">
+      <h1 className="text-3xl font-bold text-brand-dark mb-4">Coming Soon</h1>
+      <p className="text-brand-dark">This page is under construction.</p>
+    </main>
+  );
+}

--- a/src/app/components/AuthModal.tsx
+++ b/src/app/components/AuthModal.tsx
@@ -13,6 +13,7 @@ interface AuthModalProps {
   onClose: () => void;
   onSuccess?: () => void;
   disableEscape?: boolean;
+  context?: string;
 }
 
 const AuthModal = ({
@@ -20,6 +21,7 @@ const AuthModal = ({
   onClose,
   onSuccess,
   disableEscape = false,
+  context,
 }: AuthModalProps) => {
   const [mode, setMode] = useState<"login" | "signup">("login");
   const [email, setEmail] = useState("");
@@ -103,6 +105,7 @@ const AuthModal = ({
         <div className="bg-white rounded-xl p-6 w-full max-w-md shadow-lg">
           <Dialog.Title className="text-xl font-bold mb-4 text-center">
             {mode === "login" ? "Log in" : "Sign up"}
+            {context ? ` to ${context}` : ""}
           </Dialog.Title>
 
           {/* Email/password form */}

--- a/src/app/components/ui/CavemanSpot.tsx
+++ b/src/app/components/ui/CavemanSpot.tsx
@@ -21,10 +21,11 @@ const CavemanSpot = ({
   const [showAuth, setShowAuth] = useState(false);
   const [showMembership, setShowMembership] = useState(false);
 
-  const { user } = useAuth();
+  const { user, ready } = useAuth();
   const { notify } = useNotification();
 
   const handleSubmit = async () => {
+    if (!ready) return;
     if (!user) {
       setShowAuth(true); // ✅ prompt login only when adding
       return;
@@ -101,6 +102,7 @@ const CavemanSpot = ({
       <AuthModal
         isOpen={showAuth}
         onClose={() => setShowAuth(false)}
+        context="start spotting your caveman"
         disableEscape
       />
     </div>

--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -14,6 +14,7 @@ interface AuthContextType {
   user: User | null;
   login: () => Promise<void>;
   logout: (redirect?: boolean) => Promise<void>;
+  ready: boolean;
 }
 
 
@@ -21,6 +22,7 @@ const AuthContext = createContext<AuthContextType | null>(null);
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
+  const [ready, setReady] = useState(false);
 
   // On mount → try refresh first, then fallback to /me
   useEffect(() => {
@@ -59,6 +61,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         }
       } catch {
         setUser(null);
+      } finally {
+        setReady(true);
       }
     };
 
@@ -105,7 +109,7 @@ const logout = async (redirect: boolean = false) => {
 
 
   return (
-    <AuthContext.Provider value={{ user, login, logout }}>
+    <AuthContext.Provider value={{ user, login, logout, ready }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/app/diagnostics/cic/DiagnosticQuestion.tsx
+++ b/src/app/diagnostics/cic/DiagnosticQuestion.tsx
@@ -148,6 +148,7 @@ const DiagnosticQuestion = ({ onComplete }: Props) => {
       <AuthModal
         isOpen={showAuth}
         onClose={() => setShowAuth(false)}
+        context="view the result"
         onSuccess={() => {
           setShowAuth(false);
           onComplete(responses); // resume after login

--- a/src/app/insights/all/page.tsx
+++ b/src/app/insights/all/page.tsx
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
 import Link from "next/link";
+import { slugifyTag } from "../../utils/slug";
 
 interface ArticleMeta {
   slug: string;
@@ -52,7 +53,7 @@ export default function AllInsightsPage() {
           {Object.entries(tagCounts).map(([tag, count]) => (
             <li key={tag}>
               <Link
-                href={`/tags/${tag}`}
+                href={`/tags/${slugifyTag(tag)}`}
                 className="flex justify-between text-sm text-[#042a2b] hover:text-[#ed254e] transition"
               >
                 <span>{tag}</span>
@@ -83,7 +84,7 @@ export default function AllInsightsPage() {
             {article.tags?.map((tag) => (
               <Link
                 key={tag}
-                href={`/tags/${tag}`}
+                href={`/tags/${slugifyTag(tag)}`}
                 className="px-2 py-1 text-xs rounded bg-brand-secondary/20 text-brand-dark hover:bg-brand-secondary/30 transition"
               >
                 {tag}

--- a/src/app/microchallenge/page.tsx
+++ b/src/app/microchallenge/page.tsx
@@ -77,7 +77,7 @@ export default function MicrochallengePage() {
 
       {/* CTA */}
       <div className="text-center">
-         <ProtectedCTA redirect="/tools/microchallenges">
+         <ProtectedCTA redirect="/tools/microchallenges" context="start microchallenges">
           Join a Microchallenge
         </ProtectedCTA>
       </div>

--- a/src/app/modern-caveman/page.tsx
+++ b/src/app/modern-caveman/page.tsx
@@ -1,0 +1,8 @@
+export default function ModernCavemanPage() {
+  return (
+    <main className="max-w-3xl mx-auto px-6 py-20 text-center">
+      <h1 className="text-3xl font-bold text-brand-dark mb-4">Coming Soon</h1>
+      <p className="text-brand-dark">This page is under construction.</p>
+    </main>
+  );
+}

--- a/src/app/saved/page.tsx
+++ b/src/app/saved/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useAuth } from "@/app/context/AuthContext";
+import AuthModal from "../components/AuthModal";
 
 interface SavedArticle {
   slug: string;
@@ -11,11 +12,13 @@ interface SavedArticle {
 }
 
 export default function SavedArticlesPage() {
-  const { user } = useAuth();
+  const { user, ready } = useAuth();
   const [articles, setArticles] = useState<SavedArticle[]>([]);
   const [loading, setLoading] = useState(true);
+  const [showAuth, setShowAuth] = useState(false);
 
   useEffect(() => {
+    if (!ready) return;
     if (!user) {
       setLoading(false);
       return;
@@ -43,9 +46,20 @@ export default function SavedArticlesPage() {
 
   if (!user) {
     return (
-      <p className="text-center mt-12">
-        Please log in to view saved articles.
-      </p>
+      <div className="text-center mt-12">
+        Please
+        <button
+          onClick={() => setShowAuth(true)}
+          className="text-[#5eb1bf] font-semibold hover:underline ml-1"
+        >
+          log in
+        </button>{" "}
+        to view saved articles.
+        <AuthModal
+          isOpen={showAuth}
+          onClose={() => setShowAuth(false)}
+        />
+      </div>
     );
   }
 

--- a/src/app/spot/page.tsx
+++ b/src/app/spot/page.tsx
@@ -73,7 +73,7 @@ export default function SpotPage() {
 
       {/* CTA */}
       <div className="text-center">
-         <ProtectedCTA redirect="/tools/spots">
+         <ProtectedCTA redirect="/tools/spots" context="start spotting your caveman">
           Start Spotting Your Caveman
         </ProtectedCTA>
       </div>

--- a/src/app/tools/microchallenges/page.tsx
+++ b/src/app/tools/microchallenges/page.tsx
@@ -28,10 +28,11 @@ const MicrochallengesPage = () => {
   const [showAuth, setShowAuth] = useState(false);
   const [loading, setLoading] = useState(true);
 
-  const { user } = useAuth();
+  const { user, ready } = useAuth();
 
   useEffect(() => {
     const fetchChallenges = async () => {
+      if (!ready) return;
       if (!user) {
         setLoading(false);
         return;
@@ -59,6 +60,7 @@ const MicrochallengesPage = () => {
   };
 
   const handleLog = async (challengeId: string) => {
+    if (!ready) return;
     if (!user) {
       setShowAuth(true);
       return;
@@ -197,7 +199,11 @@ const MicrochallengesPage = () => {
         </Link>
       </div>
 
-      <AuthModal isOpen={showAuth} onClose={() => setShowAuth(false)} />
+      <AuthModal
+        isOpen={showAuth}
+        onClose={() => setShowAuth(false)}
+        context="start microchallenges"
+      />
     </div>
   );
 };

--- a/src/app/tools/spots/page.tsx
+++ b/src/app/tools/spots/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { useAuth } from "@/app/context/AuthContext";
 import CavemanSpot from "../../components/ui/CavemanSpot";
 import MembershipModal from "../../components/MembershipModal";
+import AuthModal from "../../components/AuthModal";
 import { usageLimits } from "../../utils/usage";
 
 interface Spot {
@@ -15,13 +16,14 @@ interface Spot {
 const SpotsPage = () => {
   const [spots, setSpots] = useState<Spot[]>([]);
   const [loading, setLoading] = useState(true);
-  const [, setShowAuth] = useState(false);
+  const [showAuth, setShowAuth] = useState(false);
   const [showMembership, setShowMembership] = useState(false);
 
-   const { user } = useAuth();
+   const { user, ready } = useAuth();
 
   useEffect(() => {
     const fetchSpots = async () => {
+      if (!ready) return;
       if (!user) {
         setLoading(false);
         return;
@@ -156,6 +158,11 @@ const SpotsPage = () => {
         isOpen={showMembership}
         onClose={() => setShowMembership(false)}
         disableEscape
+      />
+      <AuthModal
+        isOpen={showAuth}
+        onClose={() => setShowAuth(false)}
+        context="start spotting your caveman"
       />
     </div>
   );

--- a/src/app/utils/protectedCTA.tsx
+++ b/src/app/utils/protectedCTA.tsx
@@ -8,14 +8,16 @@ import AuthModal from "../components/AuthModal";
 interface ProtectedCTAProps {
   children: React.ReactNode;
   redirect: string; // where to go after auth
+  context?: string;
 }
 
-const ProtectedCTA = ({ children, redirect }: ProtectedCTAProps) => {
-  const { user } = useAuth();
+const ProtectedCTA = ({ children, redirect, context }: ProtectedCTAProps) => {
+  const { user, ready } = useAuth();
   const router = useRouter();
   const [showAuth, setShowAuth] = useState(false);
 
   const handleClick = () => {
+    if (!ready) return;
     if (user) {
       router.push(redirect); // ✅ already logged in
     } else {
@@ -36,6 +38,7 @@ const ProtectedCTA = ({ children, redirect }: ProtectedCTAProps) => {
       <AuthModal
         isOpen={showAuth}
         onClose={() => setShowAuth(false)}
+        context={context}
         onSuccess={() => {
           setShowAuth(false);
           router.push(redirect); // ✅ redirect after successful login/signup

--- a/tests/AuthModal.test.tsx
+++ b/tests/AuthModal.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom';
+import AuthModal from '../src/app/components/AuthModal';
+
+vi.mock('../src/app/context/AuthContext', () => ({
+  useAuth: () => ({ login: async () => {}, logout: async () => {}, user: null, ready: true })
+}));
+
+vi.mock('../src/app/components/NotificationProvider', () => ({
+  useNotification: () => ({ notify: () => {} })
+}));
+
+describe('AuthModal', () => {
+  it('renders custom context text', () => {
+    render(<AuthModal isOpen={true} onClose={() => {}} context="view the result" />);
+    expect(screen.getByText('Log in to view the result')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Sign up'));
+    expect(screen.getByText('Sign up to view the result')).toBeInTheDocument();
+  });
+});

--- a/tests/slug.test.ts
+++ b/tests/slug.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { slugifyTag, unslugifyTag } from '../src/app/utils/slug';
+
+describe('slug utilities', () => {
+  it('slugifyTag converts to kebab-case', () => {
+    expect(slugifyTag('The Modern Caveman')).toBe('the-modern-caveman');
+  });
+
+  it('unslugifyTag reverses slugifyTag', () => {
+    const original = 'The Modern Caveman';
+    expect(unslugifyTag(slugifyTag(original))).toBe('the modern caveman');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    environment: 'jsdom'
+  }
+});


### PR DESCRIPTION
## Summary
- ensure auth context exposes readiness to prevent premature prompts and guest limits
- slugify article tags and add placeholder pages for broken links
- support contextual login messaging and protected redirects for microchallenges and spotting

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7da36c1f4832d941d33f3cdbc9c0a