### PR TITLE
Fix auth prompts and modal behavior

### DIFF
--- a/src/app/components/ArticleLayout.tsx
+++ b/src/app/components/ArticleLayout.tsx
@@ -388,8 +388,12 @@ const ArticleLayout = ({
         context={authContext || undefined}
         onSuccess={() => {
           setShowAuth(false);
-          authCallback?.();
-          setAuthCallback(null);
+          if (authCallback) {
+            setTimeout(() => {
+              authCallback();
+              setAuthCallback(null);
+            }, 0);
+          }
         }}
         disableEscape
       />

--- a/src/app/tools/microchallenges/page.tsx
+++ b/src/app/tools/microchallenges/page.tsx
@@ -35,6 +35,7 @@ const MicrochallengesPage = () => {
       if (!ready) return;
       if (!user) {
         setLoading(false);
+        setShowAuth(true);
         return;
       }
       try {
@@ -53,7 +54,7 @@ const MicrochallengesPage = () => {
     };
 
     fetchChallenges();
-  }, [user]); // ✅ depend on user
+  }, [user, ready]);
 
   const toggleOpen = (id: string) => {
     setOpenId(openId === id ? null : id);

--- a/src/app/tools/spots/page.tsx
+++ b/src/app/tools/spots/page.tsx
@@ -26,12 +26,13 @@ const SpotsPage = () => {
       if (!ready) return;
       if (!user) {
         setLoading(false);
+        setShowAuth(true);
         return;
       }
 
       try {
         const res = await fetch("/api/spots", {
-         method: "GET",
+          method: "GET",
           credentials: "include", // 👈 send cookies
         });
 
@@ -49,7 +50,7 @@ const SpotsPage = () => {
     };
 
     fetchSpots();
-  }, [user]);
+  }, [user, ready]);
 
   const userLimit = usageLimits.user.spots || 0;
   const hasReachedLimit = user && spots.length >= userLimit;


### PR DESCRIPTION
## Summary
- Show auth modal when guests visit microchallenges or spots
- Ensure login modal closes after saving article as guest

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching @testing-library/jest-dom)*
- `npm run lint` *(fails: 8 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e2920178832d878b5e200216df4b