### PR TITLE
Ensure articles save after logging in

### DIFF
--- a/src/app/components/ArticleLayout.tsx
+++ b/src/app/components/ArticleLayout.tsx
@@ -146,11 +146,11 @@ const ArticleLayout = ({
   }, [slug, ready]);
 
   // ✅ Save / Unsave toggle
-  const handleSave = async () => {
+  const handleSave = async (skipAuthCheck = false) => {
     if (!slug || !ready) return;
-    if (!user) {
+    if (!user && !skipAuthCheck) {
       setAuthContext("save this article");
-      setAuthCallback(() => handleSave);
+      setAuthCallback(() => () => handleSave(true));
       setShowAuth(true);
       return;
     }


### PR DESCRIPTION
## Summary
- Allow save action to retry automatically after auth by skipping user check in callback

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Unexpected any, missing dependencies, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e65876b0832db8c22283e4cde16a