### PR TITLE
refactor: allow skip auth on save

### DIFF
--- a/src/app/components/ArticleLayout.tsx
+++ b/src/app/components/ArticleLayout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReactNode, useEffect, useRef, useState } from "react";
+import type React from "react";
 import Link from "next/link";
 import { Twitter, Linkedin, Mail } from "lucide-react";
 import ScrollProgress from "./ui/ScrollProgress";
@@ -146,11 +147,15 @@ const ArticleLayout = ({
   }, [slug, ready]);
 
   // ✅ Save / Unsave toggle
-  const handleSave = async () => {
+  const handleSave = async (
+    e?: React.MouseEvent<HTMLButtonElement>,
+    skipAuthCheck = false,
+  ) => {
+    e?.preventDefault();
     if (!slug || !ready) return;
-    if (!user) {
+    if (!skipAuthCheck && !user) {
       setAuthContext("save this article");
-      setAuthCallback(() => handleSave);
+      setAuthCallback(() => () => handleSave(undefined, true));
       setShowAuth(true);
       return;
     }


### PR DESCRIPTION
## Summary
- refine article save handler to accept click event and optional auth skip
- set auth callback to call handler with auth check skipped

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden retrieving @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f784b740832d90a1a5ba2d02998e