### PR TITLE
feat: track UI events in PostHog

### DIFF
--- a/src/app/components/ArticleLayout.tsx
+++ b/src/app/components/ArticleLayout.tsx
@@ -112,6 +112,9 @@ const ArticleLayout = ({
       credentials: "include",
     });
 
+    // 🔹 Track article read
+    trackEvent("Article Read", { slug });
+
     if (user) {
       // 🔑 Check localStorage instead of backend response
       const usage = JSON.parse(localStorage.getItem("usage_user") || "{}");

--- a/src/app/components/PostHogProvider.tsx
+++ b/src/app/components/PostHogProvider.tsx
@@ -28,18 +28,57 @@ export default function PostHogProvider({ children }: { children: React.ReactNod
     posthog.capture("$pageview");
   }, [pathname]);
 
-  // 🔹 Track CTA clicks (elements with data-cta attr)
+  // 🔹 Track CTA clicks, generic button/link clicks
   useEffect(() => {
     const handler = (e: MouseEvent) => {
-      const target = (e.target as HTMLElement).closest("[data-cta]") as HTMLElement | null;
-      if (target) {
-        const cta = target.getAttribute("data-cta") || "unknown";
+      const target = e.target as HTMLElement;
+
+      // CTA elements explicitly tagged
+      const ctaTarget = target.closest("[data-cta]") as HTMLElement | null;
+      if (ctaTarget) {
+        const cta = ctaTarget.getAttribute("data-cta") || "unknown";
         trackEvent("CTA Clicked", { cta });
         posthog.capture("CTA Clicked", { cta });
       }
+
+      // Generic button tracking
+      const button = target.closest("button");
+      if (button) {
+        const label =
+          button.getAttribute("aria-label") || button.textContent?.trim() || "unknown";
+        trackEvent("Button Clicked", { label });
+        posthog.capture("Button Clicked", { label });
+      }
+
+      // Generic link tracking
+      const link = target.closest("a");
+      if (link) {
+        const href = link.getAttribute("href") || "";
+        const label = link.textContent?.trim() || href || "unknown";
+        trackEvent("Link Clicked", { href, label });
+        posthog.capture("Link Clicked", { href, label });
+      }
     };
+
     document.addEventListener("click", handler);
     return () => document.removeEventListener("click", handler);
+  }, []);
+
+  // 🔹 Track form submissions
+  useEffect(() => {
+    const handleSubmit = (e: Event) => {
+      const form = e.target as HTMLFormElement;
+      const formName =
+        form.getAttribute("name") ||
+        form.getAttribute("id") ||
+        form.getAttribute("action") ||
+        "unknown";
+      trackEvent("Form Submitted", { form: formName });
+      posthog.capture("Form Submitted", { form: formName });
+    };
+
+    document.addEventListener("submit", handleSubmit);
+    return () => document.removeEventListener("submit", handleSubmit);
   }, []);
 
   return <>{children}</>;

--- a/src/app/diagnostics/cic/DiagnosticQuestion.tsx
+++ b/src/app/diagnostics/cic/DiagnosticQuestion.tsx
@@ -5,6 +5,7 @@ import { diagnosticQuestions } from "./questions";
 import FeedbackOverlay from "./FeedbackOverlay";
 import { useAuth } from "@/app/context/AuthContext";
 import AuthModal from "../../components/AuthModal";
+import { trackEvent } from "@/app/utils/analytics";
 
 interface Props {
   onComplete: (responses: Record<string, string>) => void;
@@ -34,6 +35,11 @@ const DiagnosticQuestion = ({ onComplete }: Props) => {
     if (!selectedOption) return;
 
     if (currentIndex + 1 < diagnosticQuestions.length) {
+      trackEvent("Diagnostic Step Completed", {
+        step: currentIndex + 1,
+        questionId: question.id,
+        answer: selectedOption,
+      });
       setCurrentIndex((prev) => prev + 1);
     } else {
       // ✅ Protect finish behind login
@@ -41,6 +47,7 @@ const DiagnosticQuestion = ({ onComplete }: Props) => {
         setShowAuth(true);
         return;
       }
+      trackEvent("Diagnostic Completed", { responses });
       onComplete(responses);
     }
   };


### PR DESCRIPTION
## Summary
- track generic button, link and form events in PostHogProvider
- log article reads when users reach article thresholds
- capture diagnostic question steps and completion events

## Testing
- `npm test` *(fails: Cannot find dependency '@vitest/coverage-v8')*


------
https://chatgpt.com/codex/tasks/task_e_68c660019198832d820933593790dd2f